### PR TITLE
Hide Jumbotron Text on Other Page

### DIFF
--- a/src/assets/jss/material-kit-react/views/aboutPage.js
+++ b/src/assets/jss/material-kit-react/views/aboutPage.js
@@ -28,7 +28,7 @@ const aboutPageStyle = {
     zIndex: "3"
   },
   mainRaised: {
-    margin: "-60px 30px 0px",
+    margin: "-550px 30px 0px",
     borderRadius: "6px",
     boxShadow:
       "0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.2)"

--- a/src/components/Parallax/Parallax.js
+++ b/src/components/Parallax/Parallax.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
 // nodejs library that concatenates classes
 import classNames from "classnames";
 // nodejs library to set properties for components
@@ -11,7 +12,7 @@ import styles from "assets/jss/material-kit-react/components/parallaxStyle.js";
 
 const useStyles = makeStyles(styles);
 
-export default function Parallax(props) {
+function Parallax(props) {
   let windowScrollTop;
   if (window.innerWidth >= 768) {
     windowScrollTop = window.pageYOffset / 3;
@@ -35,7 +36,8 @@ export default function Parallax(props) {
     var windowScrollTop = window.pageYOffset / 3;
     setTransform("translate3d(0," + windowScrollTop + "px,0)");
   };
-  const { filter, className, children, style, image, small } = props;
+  const { filter, className, children, style, image, small, location } = props;
+  const inHomePage = location.pathname === '/';
   const classes = useStyles();
   const parallaxClasses = classNames({
     [classes.parallax]: true,
@@ -52,7 +54,7 @@ export default function Parallax(props) {
         transform: transform
       }}
     >
-      {children}
+      {inHomePage && children}
     </div>
   );
 }
@@ -65,3 +67,5 @@ Parallax.propTypes = {
   image: PropTypes.string,
   small: PropTypes.bool
 };
+
+export default withRouter(Parallax);


### PR DESCRIPTION
[Issue](https://github.com/BrandonArmand/Binari/issues/9)

Using [withRouter](https://reacttraining.com/react-router/web/api/withRouter) of react, added logic to hide jumbotron text when the page is not home ("/").

Moved about page to the top now that the jumbotron has no text in it.

Home page (visually not affected):
![image](https://user-images.githubusercontent.com/47067313/74180238-eea86f80-4c1d-11ea-9c8d-78df7d7ddf35.png)

About page:
![image](https://user-images.githubusercontent.com/47067313/74180279-fff17c00-4c1d-11ea-9fdb-e5b9af466523.png)
