### PR TITLE
Added Keyboard Shortcut

### DIFF
--- a/src/views/Playground/Playground.js
+++ b/src/views/Playground/Playground.js
@@ -38,6 +38,17 @@ export default function Playground(props) {
   let canvas;
   let debug;
 
+  document.onkeydown = function(e) {
+    //CTRL + ENTER to run code
+    if (e.ctrlKey && e.keyCode == 13) {
+      document.getElementById("btnRunCode").click(); 
+    }
+    //CTRL + ALT + R to Reset code
+    if (e.ctrlKey && e.altKey && e.which == 82 == 82) {
+      document.getElementById("btnReset").click();
+    }
+  };
+
   function changePage(newPage) {
     setPage(newPage);
     setCode(beautify(chapter[newPage].defaultCode));
@@ -120,17 +131,21 @@ export default function Playground(props) {
                 {debug}
                 <div className={classes.codeButtons}>
                   <Button
+                    Id = "btnRunCode"
                     color="white"
                     simple={true}
                     onClick={() => setCode(unsavedCode)}
+                    title="Run (CTR+Enter)"
                   >
                     {" "}
                     Run Code{" "}
                   </Button>
                   <Button
+                    Id = "btnReset"
                     color="warning"
                     simple={true}
                     onClick={() => setCode(beautify(chapter[page].defaultCode))}
+                    title="Run (CTRL+ALT+R)"
                   >
                     {" "}
                     Reset{" "}


### PR DESCRIPTION
Added 2 Keyboard shortcuts within Playground.

CTR+Enter = Run Code
CTRL+ALT+R = Reset

I have seen @PathakPratik comment [here ](https://github.com/BrandonArmand/Binari/issues/19#issue-554870941) about using a JS library for keyboard shortcuts but I thought since there won't be too many shortcuts and it's only going to be used within playground.js, it will be better to use plain JavaScript as its less code and easier to maintain. 