### PR TITLE
Added optional Node.color property for custom colors

### DIFF
--- a/src/views/Playground/components/Canvas.js
+++ b/src/views/Playground/components/Canvas.js
@@ -53,7 +53,14 @@ const Canvas = props => {
     /**Fills the customColors map**/
     function setColors(p5) {
         customColors = new Map([
-            ["red", p5.color(255, 0, 0)],
+            ["red", p5.color("#F44336")],
+            ["pink", p5.color("#E91E63")],
+            ["purple", p5.color("#9C27B0")],
+            ["blue", p5.color("#2196F3")],
+            ["cyan", p5.color("#00BCD4")],
+            ["green", p5.color("#4CAF50")],
+            ["yellow", p5.color("#FFEB3B")],
+            ["orange", p5.color("#FF9800")]
         ]);
     }
 
@@ -68,8 +75,6 @@ const Canvas = props => {
             if (el.right != null) {
                 p5.line(el.x, el.y, el.right.x, el.right.y);
             }
-
-            p5.text(el.color, el.x, el.y - (6 + elementScale));
 
             //Retrieve custom color
             let color = customColors.get(el.color);

--- a/src/views/Playground/components/Canvas.js
+++ b/src/views/Playground/components/Canvas.js
@@ -2,11 +2,13 @@ import React from "react";
 import Sketch from "react-p5";
 import PropTypes from "prop-types";
 
+/*A map containing all custom colors name-value pairs*/
+let customColors;
+
 const Canvas = props => {
     const elementScale =
     window.devicePixelRatio < 2 ? 2 : window.devicePixelRatio;
     const windowSize = elementScale * 500;
-
     /*Array of all nodes*/
     var nodeList;
     /*All nodes represented as a reference to the root node*/
@@ -39,12 +41,20 @@ const Canvas = props => {
         p5.createCanvas(windowSize, 1000).parent(canvasParentRef);
         p5.frameRate(100);
         setTree();
+        setColors(p5);
     }
 
     function setTree() {
         nodeList = [];
         //Generate all position and layer data
         return positionNode(tree, 1, 1);
+    }
+
+    /**Fills the customColors map**/
+    function setColors(p5) {
+        customColors = new Map([
+            ["red", p5.color(255, 0, 0)],
+        ]);
     }
 
     function draw(p5) {
@@ -58,11 +68,22 @@ const Canvas = props => {
             if (el.right != null) {
                 p5.line(el.x, el.y, el.right.x, el.right.y);
             }
+
+            p5.text(el.color, el.x, el.y - (6 + elementScale));
+
+            //Retrieve custom color
+            let color = customColors.get(el.color);
+
+            //No custom color, draw the default one
+            if (color === undefined) {
+                color = p5.color(p5.map(el.value, 100, 0, 0, 255), 220, 250);
+            }
+
             //Draw node
             p5.textAlign(p5.CENTER);
             p5.stroke(0);
             p5.strokeWeight(1);
-            p5.fill(p5.map(el.value, 100, 0, 0, 255), 220, 250);
+            p5.fill(color);
             p5.ellipse(el.x, el.y, 17 * elementScale);
             p5.noStroke();
             p5.fill("black");

--- a/src/views/Playground/components/Canvas.js
+++ b/src/views/Playground/components/Canvas.js
@@ -52,15 +52,16 @@ const Canvas = props => {
 
     /**Fills the customColors map**/
     function setColors(p5) {
+        //A color has a value and a darkText bool property to indicate whether the text rendered on it should be dark
         customColors = new Map([
-            ["red", p5.color("#F44336")],
-            ["pink", p5.color("#E91E63")],
-            ["purple", p5.color("#9C27B0")],
-            ["blue", p5.color("#2196F3")],
-            ["cyan", p5.color("#00BCD4")],
-            ["green", p5.color("#4CAF50")],
-            ["yellow", p5.color("#FFEB3B")],
-            ["orange", p5.color("#FF9800")]
+            ["red", {value: p5.color("#F44336"), darkText: false,}],
+            ["pink", {value: p5.color("#E91E63"), darkText: false,}],
+            ["purple", {value: p5.color("#9C27B0"), darkText: false,}],
+            ["blue", {value: p5.color("#2196F3"), darkText: true,}],
+            ["cyan", {value: p5.color("#00BCD4"), darkText: true,}],
+            ["green", {value: p5.color("#4CAF50"), darkText: true,}],
+            ["yellow", {value: p5.color("#FFEB3B"), darkText: true,}],
+            ["orange", {value: p5.color("#FF9800"), darkText: true,}]
         ]);
     }
 
@@ -77,11 +78,16 @@ const Canvas = props => {
             }
 
             //Retrieve custom color
-            let color = customColors.get(el.color);
+            let darkText = true;
+            let color;
+            let colorArg = customColors.get(el.color);
 
             //No custom color, draw the default one
-            if (color === undefined) {
+            if (colorArg === undefined) {
                 color = p5.color(p5.map(el.value, 100, 0, 0, 255), 220, 250);
+            } else {
+                color = colorArg.value;
+                darkText = colorArg.darkText;
             }
 
             //Draw node
@@ -91,7 +97,7 @@ const Canvas = props => {
             p5.fill(color);
             p5.ellipse(el.x, el.y, 17 * elementScale);
             p5.noStroke();
-            p5.fill("black");
+            p5.fill(darkText ? "black" : "white");
             if (el.value !== null) {
                 p5.text(el.value, el.x, el.y + (6 + elementScale));
             }


### PR DESCRIPTION
I have added a way to change the color of a node by setting the Node.color attribute.

Changing the color of a node can be useful to highlight it for debugging or to display a path within the tree (for instance, with a binary search).

![dfs](https://user-images.githubusercontent.com/47389402/89666244-4af10100-d8da-11ea-8144-7c76fec490f2.png)

Node.color is a string and is optional, the name of the color and can be one of these :

- red
- pink
- purple
- blue
- cyan
- green
- yellow
- orange

![colors](https://user-images.githubusercontent.com/47389402/89666241-4a586a80-d8da-11ea-8321-8c6173ebc4af.png)

These colors are from [the 2014 material design palette](https://material.io/design/color/the-color-system.html#tools-for-picking-colors).

The color of the value label of a node can be either black or white depending on the color.
