### PR TITLE
added default avatar pic in ContributorCard for About page

### DIFF
--- a/src/views/About/components/Card.js
+++ b/src/views/About/components/Card.js
@@ -21,7 +21,7 @@ const ContributorCard = props => {
             <Card>
                 <CardHeader color={props.color}>
                     <div className={classes.cardHeader}>
-                        <img className={classes.cardImg} src={props.avatar} alt="Avatar"></img>
+                        <img className={classes.cardImg} src={props.avatar} onError={(e)=>{e.target.onerror = null; e.target.src="http://www.gravatar.com/avatar/?d=mp&s=350"}} alt="Avatar"></img>
                         <div className={classes.wrapper}>
                             {props.linkedin && (
                                 <Button simple href={props.linkedin}>


### PR DESCRIPTION
#### I noticed that the About page had avatar issues for the team section, so I thought of fixing this issue by adding a default avatar pic in case the image doesn't load. 
![before](https://user-images.githubusercontent.com/47604252/102711429-17d06c80-42d3-11eb-9ec9-0b56bce6cb8b.jpg)




#### I did this by modifying only 1 line in the code, by adding onError functionality within the image tag,  to display a default avatar pic in case the original image fails to load.
#### The default avatar pic is taken from www.gravatar.com, with the option : mystery person (abbreviation : mp)  and size : 350 pixels. 
#### After modification, the About page now looks like this : 
![after](https://user-images.githubusercontent.com/47604252/102711433-199a3000-42d3-11eb-8f33-771ced6994dc.jpg)
