### PR TITLE
Navbar font adjustments for readability

### DIFF
--- a/src/assets/jss/material-kit-react/components/headerLinksStyle.js
+++ b/src/assets/jss/material-kit-react/components/headerLinksStyle.js
@@ -5,7 +5,7 @@ import tooltip from "assets/jss/material-kit-react/tooltipsStyle.js";
 const headerLinksStyle = theme => ({
     list: {
         ...defaultFont,
-        fontSize: "14px",
+        fontSize: "20px",
         margin: 0,
         paddingLeft: "0",
         listStyle: "none",
@@ -41,7 +41,7 @@ const headerLinksStyle = theme => ({
         position: "relative",
         padding: "0.9375rem",
         fontWeight: "400",
-        fontSize: "12px",
+        fontSize: "16px",
         textTransform: "uppercase",
         borderRadius: "3px",
         lineHeight: "20px",

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ function App() {
                         height: 150,
                         color: "white",
                     }}
+                    style="font-size: 24px; font-weight: 800"
                 />
                 <Parallax
                     filter


### PR DESCRIPTION
Hello Binari developers. I am a first time contributor, and my experience using React with Babel is limited.

One of the first things I noticed when visiting https://binari.dev is that the navbar text doesn't have optimal readability. To address this, I changed the font size and font weight of the navbar links.

Before (top) and after (bottom) of the navbar when the parallax effect **is not** active (i.e. the page is scrolled to the top)
![Before Adjustment Dark](https://github.com/BrandonArmand/Binari/assets/82979632/d4f6a064-4cb3-4342-ad8a-3d969934d255)
![After Adjustment Dark](https://github.com/BrandonArmand/Binari/assets/82979632/c54e8785-85ce-4373-9fe5-fb2e2b861bb9)


Before (top) and after (bottom) of the navbar when the parallax effect **is** active (i.e. the page is scrolled down)
![Before Adjustment Light](https://github.com/BrandonArmand/Binari/assets/82979632/c3264222-acd5-4aac-aa7c-648a394be31a)
![After Adjustment Light](https://github.com/BrandonArmand/Binari/assets/82979632/b28449d3-0e32-424a-a9f5-1200836d75c4)

I hope these changes seem reasonable and actionable in your eyes. Since I am not very experienced using React, I understand that these changes may not use the best conventions. If you agree with the design change, please feel free to create a new PR implementing these changes with better programming conventions.

Note: This pull request has been opened for credit in a university course.